### PR TITLE
Fix extraneous closing tags

### DIFF
--- a/feebat/quiz/js/validquiz-autoplay.js
+++ b/feebat/quiz/js/validquiz-autoplay.js
@@ -403,8 +403,8 @@ $(document).ready(function () {
                 <div class="toast-body">
                   <div class="card">
                     <div class="card-body"> 
-                      <h6>${jsonData.interactive_hot_spots[i].success_title}</h6></strong>
-                      ${jsonData.interactive_hot_spots[i].success_description}
+                    <h6>${jsonData.interactive_hot_spots[i].success_title}</h6>
+                    ${jsonData.interactive_hot_spots[i].success_description}
                     </div>
                   </div>
                 </div>
@@ -452,7 +452,7 @@ $(document).ready(function () {
               <div class="toast-body">
                 <div class="card">
                   <div class="card-body"> 
-                    <h6>${jsonData.interactive_hot_spots[i].failed_title}</h6></strong>
+                    <h6>${jsonData.interactive_hot_spots[i].failed_title}</h6>
                     ${jsonData.interactive_hot_spots[i].failed_description}
                   </div>
                 </div>

--- a/feebat/quiz/js/validquiz-sv.js
+++ b/feebat/quiz/js/validquiz-sv.js
@@ -401,8 +401,8 @@ $(document).ready(function () {
                 <div class="toast-body">
                   <div class="card">
                     <div class="card-body"> 
-                      <h6>${jsonData.interactive_hot_spots[i].success_title}</h6></strong>
-                      ${jsonData.interactive_hot_spots[i].success_description}
+                    <h6>${jsonData.interactive_hot_spots[i].success_title}</h6>
+                    ${jsonData.interactive_hot_spots[i].success_description}
                     </div>
                   </div>
                 </div>
@@ -450,7 +450,7 @@ $(document).ready(function () {
               <div class="toast-body">
                 <div class="card">
                   <div class="card-body"> 
-                    <h6>${jsonData.interactive_hot_spots[i].failed_title}</h6></strong>
+                    <h6>${jsonData.interactive_hot_spots[i].failed_title}</h6>
                     ${jsonData.interactive_hot_spots[i].failed_description}
                   </div>
                 </div>

--- a/feebat/quiz/js/validquiz.js
+++ b/feebat/quiz/js/validquiz.js
@@ -438,8 +438,8 @@ $(document).ready(function () {
                 <div class="toast-body">
                   <div class="card">
                     <div class="card-body"> 
-                      <h6>${jsonData.interactive_hot_spots[i].success_title}</h6></strong>
-                      ${jsonData.interactive_hot_spots[i].success_description}
+                    <h6>${jsonData.interactive_hot_spots[i].success_title}</h6>
+                    ${jsonData.interactive_hot_spots[i].success_description}
                     </div>
                   </div>
                 </div>
@@ -487,7 +487,7 @@ $(document).ready(function () {
               <div class="toast-body">
                 <div class="card">
                   <div class="card-body"> 
-                    <h6>${jsonData.interactive_hot_spots[i].failed_title}</h6></strong>
+                    <h6>${jsonData.interactive_hot_spots[i].failed_title}</h6>
                     ${jsonData.interactive_hot_spots[i].failed_description}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove stray `</strong>` closing tags from quiz scripts

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68537067ff98832e88132103e3f011b2