### PR TITLE
Add MIT license with asset restrictions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+MIT License
+
+Copyright (c) 2024 GMV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Asset Restrictions
+
+All graphics, images, textures, icons, 3D models, and other media files in
+this repository (including *.jpg, *.png, *.glb, *.usdz, *.gif, and similar
+formats) are NOT licensed for reuse, distribution, or modification. They are
+included only for demonstration purposes. No rights are granted to use these
+assets for any purpose without explicit written permission from the respective
+copyright holders.


### PR DESCRIPTION
## Summary
- add an MIT license for the source code
- include explicit clause that the graphics and 3D models are not licensed for reuse

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537183b74c832e9c496c6bc3e911b3