### PR TITLE
Refactor quiz scripts to use fetch API

### DIFF
--- a/feebat/quiz/js/main.js
+++ b/feebat/quiz/js/main.js
@@ -8,16 +8,14 @@ console.log('*** VERY-UP/FEE-BAT: QUIZ INDEX')
 $(document).ready(function () {
   //// get json data
   let jsonData
-  let httpRequest = new XMLHttpRequest()
-  httpRequest.open('GET', 'main.json', true)
-  httpRequest.send()
-  httpRequest.addEventListener('readystatechange', function () {
-    if (this.readyState === this.DONE) {
-      jsonData = JSON.parse(this.response)
+  fetch('main.json')
+    .then((response) => response.json())
+    .then((data) => {
+      jsonData = data
       processJsonData()
       console.log(jsonData)
-    }
-  })
+    })
+    .catch((err) => console.error('Failed to load JSON:', err))
 
   //// process json data
   function processJsonData() {

--- a/feebat/quiz/js/products.js
+++ b/feebat/quiz/js/products.js
@@ -11,15 +11,13 @@ console.log('*** VERY-UP/FEE-BAT: '+product)
 $(document).ready(function () {
   //// get json data
   let jsonData
-  let httpRequest = new XMLHttpRequest()
-  httpRequest.open('GET', product+'.json', true)
-  httpRequest.send()
-  httpRequest.addEventListener('readystatechange', function () {
-    if (this.readyState === this.DONE) {
-      jsonData = JSON.parse(this.response)
+  fetch(product + '.json')
+    .then((response) => response.json())
+    .then((data) => {
+      jsonData = data
       processJsonData()
-    }
-  })
+    })
+    .catch((err) => console.error('Failed to load JSON:', err))
 
   //// process json data
   function processJsonData() {

--- a/feebat/quiz/js/validquiz-autoplay.js
+++ b/feebat/quiz/js/validquiz-autoplay.js
@@ -140,15 +140,13 @@ $(document).ready(function () {
 
   //// get json data
   
-  let httpRequest = new XMLHttpRequest()
-  httpRequest.open('GET', model+'.json', true)
-  httpRequest.send()
-  httpRequest.addEventListener('readystatechange', function () {
-    if (this.readyState === this.DONE) {
-      jsonData = JSON.parse(this.response)
+  fetch(model + '.json')
+    .then((response) => response.json())
+    .then((data) => {
+      jsonData = data
       processJsonData()
-    }
-  })
+    })
+    .catch((err) => console.error('Failed to load JSON:', err))
 
   //// process json data
   function processJsonData() {

--- a/feebat/quiz/js/validquiz-sv.js
+++ b/feebat/quiz/js/validquiz-sv.js
@@ -138,15 +138,13 @@ $(document).ready(function () {
 
   //// get json data
   
-  let httpRequest = new XMLHttpRequest()
-  httpRequest.open('GET', model+'.json', true)
-  httpRequest.send()
-  httpRequest.addEventListener('readystatechange', function () {
-    if (this.readyState === this.DONE) {
-      jsonData = JSON.parse(this.response)
+  fetch(model + '.json')
+    .then((response) => response.json())
+    .then((data) => {
+      jsonData = data
       processJsonData()
-    }
-  })
+    })
+    .catch((err) => console.error('Failed to load JSON:', err))
 
   //// process json data
   function processJsonData() {

--- a/feebat/quiz/js/validquiz.js
+++ b/feebat/quiz/js/validquiz.js
@@ -176,15 +176,13 @@ function updateHotspotPosition(posNum) {
 $(document).ready(function () {
   //// get json data
 
-  let httpRequest = new XMLHttpRequest()
-  httpRequest.open('GET', model + '.json', true)
-  httpRequest.send()
-  httpRequest.addEventListener('readystatechange', function () {
-    if (this.readyState === this.DONE) {
-      jsonData = JSON.parse(this.response)
+  fetch(model + '.json')
+    .then((response) => response.json())
+    .then((data) => {
+      jsonData = data
       processJsonData()
-    }
-  })
+    })
+    .catch((err) => console.error('Failed to load JSON:', err))
 
   //// process json data
   function processJsonData() {


### PR DESCRIPTION
## Summary
- refactor AJAX loading in quiz scripts to use `fetch`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685371e8a9dc832ea5ba4de57080ecfd