### PR TITLE
Add logo and UI elements to Total demo

### DIFF
--- a/Total/index.html
+++ b/Total/index.html
@@ -14,6 +14,50 @@
     <!-- Full page viewer -->
     <full-page id="full-page"></full-page>
 
+    <!-- Main UI -->
+    <ui>
+      <progress-bar class="progress-container fixed-top">
+        <span class="progress-bar"></span>
+      </progress-bar>
+      <brand-logo>
+        <img src="img/total-energy-logo.png" id="brand-logo" alt="TotalEnergies Logo">
+      </brand-logo>
+      <top-left-menu>
+        <button type="button" class="btn btn-primary text-light fs-3" id="info-btn" data-bs-toggle="modal" data-bs-target="#infoModal">
+          <span data-bs-toggle="tooltip" data-bs-placement="right" title="Explications">
+            <i class="bi bi-question-circle"></i>
+          </span>
+        </button>
+        <anim-button id="anim-button">
+          <button type="button" class="btn btn-primary text-light fs-3" onclick="separateView()">
+            <span data-bs-toggle="tooltip" data-bs-placement="right" title="separate-view"><i class="bi bi-layers-half"></i></span>
+          </button>
+        </anim-button>
+      </top-left-menu>
+      <bottom-left-menu>
+
+      </bottom-left-menu>
+      <bottom-centered-progress>
+        <div class="">
+          <div class="">
+            <div id="stepper-wrapper" class="stepper-wrapper">
+            </div>
+          </div>
+        </div>
+
+      </bottom-centered-progress>
+    </ui>
+
+    <!-- Modals/Toasts -->
+    <modals id="modals" >
+
+    </modals>
+
+    <!-- Loading Overlay -->
+    <overlay id="overlay" >
+      <div class="loader">Chargement...</div>
+    </overlay>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.11.1/dist/model-viewer-umd.min.js" crossorigin="anonymous"></script>
     <script src="js/viewer.js"></script>


### PR DESCRIPTION
## Summary
- add missing feebat logo to Total demo
- wrap the viewer with UI controls and overlay
- rename expected logo to total-energy-logo.png and drop placeholder

## Testing
- `git log -1 --stat`
- `ls -al Total`


------
https://chatgpt.com/codex/tasks/task_e_68537cc2dab0832eb4faf6c6ba3a7710