### PR TITLE
Add start script for local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ L’expérience se découpe en plusieurs écrans interactifs :
 - La modélisation 3D du container et de ses composants a déjà été réalisée en amont.
 - Toute contribution se fait désormais exclusivement dans le répertoire `total-bess/` ou selon les branches spécifiques du développement en cours.
 
+## Démarrer un serveur local
+
+Pour visualiser les exemples localement, exécutez :
+
+```bash
+npm install
+npm start
+```
+
+Cela lance un petit serveur HTTP et sert les fichiers du dépôt sur `http://localhost:8080`.
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "test": "echo \"No test specified\""
+    "test": "echo \"No test specified\"",
+    "start": "http-server ./ -c-1"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `http-server` dev dependency
- define `npm start` to run the local server
- explain usage in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685392c7ad1c832e86d281e4fc723936