### PR TITLE
Fix blurred modal handlers

### DIFF
--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -98,6 +98,7 @@ function setupModals() {
     const startBtn = document.getElementById('start-btn');
     if (startBtn) {
       startBtn.addEventListener('click', () => {
+        startBtn.blur();
         welcomeModal.hide();
         if (tutorialEl) {
           const tutorialModal = new bootstrap.Modal(tutorialEl);
@@ -112,6 +113,7 @@ function setupModals() {
     const closeBtn = document.getElementById('tutorial-close-btn');
     if (closeBtn) {
       closeBtn.addEventListener('click', () => {
+        closeBtn.blur();
         const tutInstance = bootstrap.Modal.getInstance(tutorialEl) || new bootstrap.Modal(tutorialEl);
         tutInstance.hide();
       });


### PR DESCRIPTION
## Summary
- blur the start button before dismissing the welcome modal
- blur the tutorial close button before hiding the tutorial modal

## Testing
- `npm test` *(fails: No test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68539905834c832ebb219362f04e9600