### PR TITLE
Enable Bootstrap tooltips

### DIFF
--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -73,6 +73,10 @@ function initUI() {
       }
     });
   }
+
+  // Initialize all Bootstrap tooltips
+  const tooltipEls = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+  tooltipEls.forEach((el) => new bootstrap.Tooltip(el));
 }
 
 function setupLoadListener() {
@@ -131,6 +135,9 @@ async function separateView() {
         <span data-bs-toggle="tooltip" data-bs-placement="right" title="${uiText.initial_view_tooltip || 'initial-view'}"><i class="bi bi-box"></i></span>
     </button>`
   );
+  document
+    .querySelectorAll('[data-bs-toggle="tooltip"]')
+    .forEach((el) => new bootstrap.Tooltip(el));
 }
 
 async function initialView() {
@@ -145,4 +152,7 @@ async function initialView() {
         <span data-bs-toggle="tooltip" data-bs-placement="right" title="${uiText.separate_view_tooltip || 'separate-view'}"><i class="bi bi-layers"></i></span>
     </button>`
   );
+  document
+    .querySelectorAll('[data-bs-toggle="tooltip"]')
+    .forEach((el) => new bootstrap.Tooltip(el));
 }


### PR DESCRIPTION
## Summary
- init Bootstrap tooltips in `initUI`
- refresh tooltips after animation view button HTML changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853990726c4832e83990019e22a3f00