### PR TITLE
Fix tutorial modal show/hide logic

### DIFF
--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -93,27 +93,31 @@ function setupModals() {
   const welcomeEl = document.getElementById('welcomeModal');
   const tutorialEl = document.getElementById('tutorialModal');
 
+  const tutorialModal = tutorialEl ? new bootstrap.Modal(tutorialEl) : null;
+
   if (welcomeEl) {
     const welcomeModal = new bootstrap.Modal(welcomeEl);
     const startBtn = document.getElementById('start-btn');
     if (startBtn) {
       startBtn.addEventListener('click', () => {
         welcomeModal.hide();
-        if (tutorialEl) {
-          const tutorialModal = new bootstrap.Modal(tutorialEl);
-          tutorialModal.show();
+        if (tutorialModal) {
+          welcomeEl.addEventListener(
+            'hidden.bs.modal',
+            () => tutorialModal.show(),
+            { once: true }
+          );
         }
       });
     }
     welcomeModal.show();
   }
 
-  if (tutorialEl) {
+  if (tutorialModal) {
     const closeBtn = document.getElementById('tutorial-close-btn');
     if (closeBtn) {
       closeBtn.addEventListener('click', () => {
-        const tutInstance = bootstrap.Modal.getInstance(tutorialEl) || new bootstrap.Modal(tutorialEl);
-        tutInstance.hide();
+        tutorialModal.hide();
       });
     }
   }


### PR DESCRIPTION
## Summary
- handle tutorial modal with a single `bootstrap.Modal` instance
- show tutorial modal only after welcome modal is fully hidden
- reuse tutorial modal instance when closing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853993a4ff8832eb2ab479bc75db467