### PR TITLE
Fix language toggle without main.json

### DIFF
--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -121,8 +121,11 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     .catch((err) => {
       console.error('Failed to load JSON:', err);
+      currentLang = detectLang();
+      applyLanguage(currentLang);
       initUI();
       setupLoadListener();
+      setupLangToggle();
     });
 });
 


### PR DESCRIPTION
## Summary
- ensure missing `main.json` doesn't break language toggle

## Testing
- `npm test`
- `npm start` *(fails before install, then succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_6853ae855764832e9fa14363a44ba93e