### PR TITLE
Remove auto-dismiss to prevent extra backdrop

### DIFF
--- a/total-bess/index.html
+++ b/total-bess/index.html
@@ -78,7 +78,7 @@
               </div>
             </div>
             <div class="modal-footer p-1">
-              <button id="modal-ok-btn" type="button" class="btn btn-secondary" data-bs-dismiss="modal">OK</button>
+              <button id="modal-ok-btn" type="button" class="btn btn-secondary">OK</button>
             </div>
           </div>
         </div>

--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -161,6 +161,20 @@ function initUI() {
       }
     });
   }
+
+  const okBtn = document.getElementById('modal-ok-btn');
+  if (okBtn) {
+    okBtn.addEventListener('click', () => {
+      okBtn.blur();
+      const infoModalEl = document.getElementById('infoModal');
+      if (infoModalEl) {
+        const infoInstance =
+          bootstrap.Modal.getInstance(infoModalEl) ||
+          new bootstrap.Modal(infoModalEl);
+        infoInstance.hide();
+      }
+    });
+  }
 }
 
 function setupLoadListener() {


### PR DESCRIPTION
## Summary
- remove Bootstrap data-bs-dismiss attributes from intro modal buttons in FEE-BAT quiz
- keep click handlers that hide each modal
- remove data-dismiss from BESS info modal button and hide it in JS

## Testing
- `npm test` *(prints 'No test specified')*

------
https://chatgpt.com/codex/tasks/task_e_6853bc60ba3c832e9ce4823d4f5276ea