### PR TITLE
Fix modal backdrop cleanup

### DIFF
--- a/feebat/quiz/js/validquiz.js
+++ b/feebat/quiz/js/validquiz.js
@@ -797,6 +797,14 @@ $(document).ready(function () {
     console.log('cameraTarget: ' + x + ' ' + y + ' ' + z)
   })
 
+  // Clean up any remaining modal backdrop when a modal is fully hidden
+  $('body').on('hidden.bs.modal', '.modal', function () {
+    if ($('.modal.show').length === 0) {
+      $('body').removeClass('modal-open')
+      $('.modal-backdrop').remove()
+    }
+  })
+
   //// display explainations at start
   setTimeout(function () {
     $('#initialModal1').modal('show') //DEV ON


### PR DESCRIPTION
## Summary
- remove leftover Bootstrap modal backdrop when closing popups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c1347094832e9621e302dbe60a0a