### PR TITLE
Add label translations and refresh UI on language switch

### DIFF
--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -21,6 +21,7 @@ function applyLanguage(lang) {
   uiText = uiData[lang] || {};
   currentLang = lang;
   updateUIText();
+  refreshTooltips();
   updateLangButton();
 }
 
@@ -40,6 +41,18 @@ function updateLangButton() {
   const enClass = currentLang === 'en' ? 'active' : 'inactive';
   const frClass = currentLang === 'fr' ? 'active' : 'inactive';
   btn.innerHTML = `<span class="${enClass}">EN</span>-<span class="${frClass}">FR</span>`;
+}
+
+function refreshTooltips() {
+  const tooltipEls = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+  tooltipEls.forEach((el) => {
+    const instance = bootstrap.Tooltip.getInstance(el);
+    if (instance) {
+      instance.setContent({ '.tooltip-inner': el.getAttribute('title') });
+    } else {
+      new bootstrap.Tooltip(el);
+    }
+  });
 }
 
 function updateUIText() {
@@ -74,6 +87,9 @@ function updateUIText() {
     tutorialModalLabel: uiText.tutorial_title,
     'tutorial-text': uiText.tutorial_text,
     'tutorial-close-btn': uiText.tutorial_button,
+    label1: uiText.label_cell,
+    label2: uiText.label_module,
+    label3: uiText.label_rack,
   };
 
   Object.entries(texts).forEach(([id, value]) => {

--- a/total-bess/main.json
+++ b/total-bess/main.json
@@ -19,7 +19,10 @@
     "start_button": "START",
     "tutorial_title": "How to manipulate the model?",
     "tutorial_text": "Use your mouse or finger to rotate and zoom on the battery.",
-    "tutorial_button": "Let's go!"
+    "tutorial_button": "Let's go!",
+    "label_cell": "Cell",
+    "label_module": "Module",
+    "label_rack": "Rack"
   },
   "fr": {
     "page_title": "Total 3D Demo",
@@ -41,6 +44,9 @@
     "start_button": "COMMENCER",
     "tutorial_title": "Comment manipuler le mod\u00e8le ?",
     "tutorial_text": "Utilisez la souris ou votre doigt pour faire pivoter et zoomer sur la batterie.",
-    "tutorial_button": "C\u2019est parti !"
+    "tutorial_button": "C\u2019est parti !",
+    "label_cell": "Cellule",
+    "label_module": "Module",
+    "label_rack": "Rack"
   }
 }


### PR DESCRIPTION
## Summary
- translate draggable labels in `main.json`
- update `viewer.js` to refresh tooltips and label texts when changing language

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c2beda50832eacf9e8c2dd15598c