### PR TITLE
Fix modal backdrop leftover on close

### DIFF
--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -113,6 +113,14 @@ document.addEventListener('DOMContentLoaded', () => {
       setupLoadListener();
       setupLangToggle();
     });
+
+  // Ensure body cleanup when multiple modals are used
+  $('body').on('hidden.bs.modal', '.modal', function () {
+    if ($('.modal.show').length === 0) {
+      $('body').removeClass('modal-open');
+      $('.modal-backdrop').remove();
+    }
+  });
 });
 
 function initUI() {


### PR DESCRIPTION
## Summary
- ensure Bootstrap modal backdrop is removed when closing multiple modals
- jQuery already loaded in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854db53b654832e9a71738f8834efd1