### PR TITLE
Use checkbox switch for language toggle

### DIFF
--- a/total-bess/css/main.css
+++ b/total-bess/css/main.css
@@ -542,3 +542,35 @@ bottom-centered-progress {
 #lang-toggle .inactive {
   color: #d1d1d1;
 }
+
+#lang-toggle {
+  width: 2.5rem;
+  height: 1.4rem;
+  background-color: #ccc;
+  border-radius: 1rem;
+  border: none;
+  appearance: none;
+  position: relative;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+#lang-toggle:checked {
+  background-color: #0066b3;
+}
+
+#lang-toggle::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1rem;
+  height: 1rem;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s ease;
+}
+
+#lang-toggle:checked::before {
+  transform: translateX(1.1rem);
+}

--- a/total-bess/index.html
+++ b/total-bess/index.html
@@ -43,7 +43,12 @@
           <div id="label3" class="draggable-label" draggable="true">Rack</div>
         </div>
 
-        <button id="lang-toggle" class="btn btn-primary fs-6"><span class="active">EN</span>-<span class="inactive">FR</span></button>
+        <div class="form-check form-switch">
+          <input class="form-check-input" type="checkbox" id="lang-toggle">
+          <label class="form-check-label" for="lang-toggle">
+            <span class="active">EN</span>-<span class="inactive">FR</span>
+          </label>
+        </div>
 
       </bottom-left-menu>
       <bottom-centered-progress>

--- a/total-bess/js/viewer.js
+++ b/total-bess/js/viewer.js
@@ -32,21 +32,25 @@ function applyLanguage(lang) {
 }
 
 function setupLangToggle() {
-  const btn = document.getElementById('lang-toggle');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    const newLang = currentLang === 'fr' ? 'en' : 'fr';
+  const toggle = document.getElementById('lang-toggle');
+  if (!toggle) return;
+  toggle.addEventListener('change', () => {
+    const newLang = toggle.checked ? 'en' : 'fr';
     applyLanguage(newLang);
   });
   updateLangButton();
 }
 
 function updateLangButton() {
-  const btn = document.getElementById('lang-toggle');
-  if (!btn) return;
-  const enClass = currentLang === 'en' ? 'active' : 'inactive';
-  const frClass = currentLang === 'fr' ? 'active' : 'inactive';
-  btn.innerHTML = `<span class="${enClass}">EN</span>-<span class="${frClass}">FR</span>`;
+  const toggle = document.getElementById('lang-toggle');
+  if (!toggle) return;
+  toggle.checked = currentLang === 'en';
+  const label = document.querySelector("label[for='lang-toggle']");
+  if (label) {
+    const enClass = currentLang === 'en' ? 'active' : 'inactive';
+    const frClass = currentLang === 'fr' ? 'active' : 'inactive';
+    label.innerHTML = `<span class="${enClass}">EN</span>-<span class="${frClass}">FR</span>`;
+  }
 }
 
 function refreshTooltips() {


### PR DESCRIPTION
## Summary
- replace language toggle button with a Bootstrap switch
- hook viewer.js toggle to checkbox change event
- show active language using checkbox state
- style the checkbox like an iOS switch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854fbbe3720832eb248b65f924bfa85